### PR TITLE
Kelp: allow multiple instances of an app

### DIFF
--- a/lib/Kelp/Module.pm
+++ b/lib/Kelp/Module.pm
@@ -22,20 +22,17 @@ sub register {
         no strict 'refs';
         no warnings 'redefine';
 
-        my $app  = ref $self->app;
-        my $glob = "${app}::$name";
-
         # Manually check if the glob is being redefined
         if ( !$ENV{KELP_REDEFINE} && $self->app->can($name) ) {
-            croak "Redefining of $glob not allowed";
+            croak "Redefining of $name not allowed";
         }
 
         if ( ref $item eq 'CODE' ) {
-            *{$glob} = $item;
+            $self->app->registered_methods->{$name} = $item;
         }
         else {
             $self->app->{$name} = $item;
-            *{$glob} = sub { $_[0]->{$name} }
+            $self->app->registered_methods->{$name} = sub { $_[0]->{$name} };
         }
     }
 }

--- a/t/module_config.t
+++ b/t/module_config.t
@@ -10,11 +10,10 @@ use Plack::Util;
 use FindBin '$Bin';
 use Test::More;
 use Test::Exception;
+use Kelp;
 
 # Basic
-my $app = Plack::Util::inline_object(
-    mode => sub { "test" }
-);
+my $app = Kelp->new( mode => 'test' );
 my $c = Kelp::Module::Config->new( app => $app );
 isa_ok $c, 'Kelp::Module::Config';
 


### PR DESCRIPTION
Kelp generally loads modules, loads config, etc. all in the context of
a specific instance, but the entire module system is setup to load
class-wide methods.

Even a very simple program like the following dies:

    use Kelp;

    Kelp->new;
    Kelp->new;
    # Redefining of Kelp::config_hash not allowed at Kelp.pm line 105.

This means you couldn't, for example, load two instances of a Kelp app
with different configs (at least not without creating subclasses).

This commit moves registered methods to a per-instance hash and
overrides `AUTOLOAD` and `can` to hook them up.  This change should
largely be backwards compatible unless class methods were being loaded
with the module system.