### PR TITLE
Add route names to requests

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -178,6 +178,7 @@ sub psgi {
 
             # Dispatch
             $self->req->named( $route->named );
+            $self->req->route_name( $route->name );
             my $data = $self->routes->dispatch( $self, $route );
 
             # Log info about the route
@@ -1247,7 +1248,7 @@ returns an instance of the class defined in the request_obj attribute (defaults 
 L<Kelp::Request>), initialized with the current request's environment. You can
 override this method to use a custom request module if you need to do something
 interesting. Though there is a provided attribute that can be used to overide
-the class of the object used. 
+the class of the object used.
 
     package MyApp;
     use MyApp::Request;

--- a/lib/Kelp/Request.pm
+++ b/lib/Kelp/Request.pm
@@ -14,6 +14,9 @@ attr stash => sub { {} };
 # The named hash contains the values of the named placeholders
 attr named => sub { {} };
 
+# The name of the matched route for this request
+attr route_name => sub { undef };
+
 # If you're running the web app as a proxy, use Plack::Middleware::ReverseProxy
 sub address     { $_[0]->env->{REMOTE_ADDR} }
 sub remote_host { $_[0]->env->{REMOTE_HOST} }
@@ -121,6 +124,11 @@ that you can use to pass data from one route to another.
 
 This hash is initialized with the named placeholders of the path that the
 current route is processing.
+
+=head2 route_name
+
+Contains a string name of the route matched for this request. Contains route pattern
+if the route was not named.
 
 =head2 param
 


### PR DESCRIPTION
This is a very subtle change that adds a single property to Kelp::Request and populates it in Kelp. That property contains the name of currently parsed route. For request trees, it will change between each route handler, just as named parameters in requests.

The reason for this change is to allow for a bit more context on where in the system we currently are. This could be used to introduce some kind of request preprocessing by providing an alternate request implementation that checks the route name after it's set.

All in all, this will enable creating maps of behavior assigned to route names. It can be done currently by replacing Kelp::Router with something that gets a bit more context out of the route it's dispatching, but given how small a change this is I don't see why not attach it by default.