### PR TITLE
Multiple instances of an app - another approach

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -455,6 +455,25 @@ contain a reference to the current L<Kelp::Response> instance.
 
 =head1 METHODS
 
+=head2 new
+
+    my $the_only_kelp = KelpApp->new;
+
+A standard constructor. B<Cannot> be called multiple times: see L</new_anon>.
+
+=head2 new_anon
+
+    my $kelp1 = KelpApp->new_anon(config => 'conf1');
+    my $kelp2 = KelpApp->new_anon(config => 'conf2');
+
+A constructor that can be called repeatedly. Cannot be mixed with L</new>.
+
+It works by creating a new anonymous class extending the class of your
+application and running I<new> on it. C<ref $kelp> will return I<something
+else> than the name of your Kelp class, but C<< $kelp->isa('KelpApp') >> will
+be true. This will likely be useful during testing or when running multiple
+instances of the same application with different configurations.
+
 =head2 build
 
 On its own, the C<build> method doesn't do anything. It is called by the

--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -71,17 +71,20 @@ sub new_anon {
     my $anon_class = "Kelp::Anonymous::$class" . ++$last_anon;
     my $err = do {
         local $@;
-        eval qq[
+        my $eval_status = eval qq[
             {
                 package $anon_class;
                 use parent -norequire, '$class';
             }
+            1;
         ];
-        $@;
+        $@ || !$eval_status;
     };
 
-    die "Couldn't create anonymous Kelp instance: $err"
-        if $err;
+    if ($err) {
+        die "Couldn't create anonymous Kelp instance: " .
+            (length $err > 1 ? $err : 'unknown error');
+    }
 
     return $anon_class->new(@_);
 }

--- a/t/new_anonymous.t
+++ b/t/new_anonymous.t
@@ -32,6 +32,11 @@ isnt
     scalar @{$app2->routes->routes},
     'routes storage ok';
 
+# Check for possible string eval problems
+throws_ok sub {
+    Kelp::new_anon(qq[';#\ndie 'not what was expected']); # <- try hack the class name
+}, qr/^invalid class ';/, 'eval checks ok';
+
 # The limitation is that we can't mix ->new and ->new_anon
 throws_ok sub {
     $app1 = Kelp->new( mode => 'test' );

--- a/t/new_anonymous.t
+++ b/t/new_anonymous.t
@@ -1,0 +1,41 @@
+use Kelp::Base -strict;
+
+use Kelp;
+use Kelp::Test;
+use HTTP::Request::Common;
+use Test::More;
+use Test::Exception;
+use Scalar::Util qw(blessed refaddr);
+
+my ($app1, $app2);
+
+lives_ok sub {
+    $app1 = Kelp->new_anon( mode => 'test' );
+    $app2 = Kelp->new_anon( mode => 'test' );
+}, 'construction ok';
+
+ok $app1, 'first anonymous app ok';
+ok $app2, 'second anonymous app ok';
+
+like blessed $app1, qr/^Kelp::Anonymous::/, 'first app class ok';
+like blessed $app2, qr/^Kelp::Anonymous::/, 'second app class ok';
+
+isa_ok $app1, 'Kelp';
+isa_ok $app2, 'Kelp';
+
+isnt refaddr $app1->routes, refaddr $app2->routes, 'not the same app routes ok';
+
+$app1->routes->add('/', sub { 'hello' });
+
+isnt
+    scalar @{$app1->routes->routes},
+    scalar @{$app2->routes->routes},
+    'routes storage ok';
+
+# The limitation is that we can't mix ->new and ->new_anon
+throws_ok sub {
+    $app1 = Kelp->new( mode => 'test' );
+    $app2 = Kelp->new_anon( mode => 'test' );
+}, qr/Redefining of .+ not allowed/, 'limitations ok';
+
+done_testing;


### PR DESCRIPTION
I'm coming back to the issue of multiple instances, since I encountered (and 'fixed') this problem in one of my Kelp modules.

Surely we don't want #62 in its current form because it is a breaking change - even if minor. We can't truly know how many systems will it break, so it's too risky. This is why I propose an alternative that will ensure full backwards compatibility.

All this PR contains is one additional method to Kelp.pm, which is `new_anon`. What it does is create a new anonymous class in eval with simple `use parent -norequire` and then construct it instead. A new lexical variable is also introduced to the package (but private), that autoincrements each time a class is generated - this way we're sure to have no name collisions.

So now current users won't see any change at all, because it only changes anything when you call `new_anon` somewhere.

A limitation to that approach is that you can't mix `->new` and `->new_anon`. If new_anon is called after new, it will throw redefining exception as usual. If it is called before new, it should work but can possibly lead to buggy code (since stuff will be defined on two levels, if one of them calls SUPER it will do much more than it should).

All of this is documented and a new test is introduced to check that behavior. All of the test suite seem to pass for me on 5.32.0 and 5.10.1, but it should still be released (if merged) as a development version to see what CPAN testers have to say about it.

Of course, it collides with #62 - it's either one or the other. @aeruder you can take a look as well if you're still interested in Kelp.