### PR TITLE
JSON::MaybeXS

### DIFF
--- a/lib/Kelp/Manual.pod
+++ b/lib/Kelp/Manual.pod
@@ -90,8 +90,8 @@ module of your choice to return rich text, html and JSON responses.
 
 =item
 
-B<JSON encoder/decoder>. Kelp comes with JSON, but you can easily plug in JSON::XS
-or any decoder of your choice.
+B<JSON encoder/decoder>. Kelp comes with JSON::MaybeXS, which will
+automatically choose the best (fastest, most secure) backend available.
 
 =item
 
@@ -730,8 +730,9 @@ L<Kelp::Module::JSON> for example:
 
     sub build {
         my ( $self, %args ) = @_;
-        my $json = JSON->new;
-        $json->property( $_ => $args{$_} ) for keys %args;
+        my $json = JSON::MaybeXS->new(
+            map { $_ => $args{$_} } keys %args
+        );
         $self->register( json => $json );
     }
 
@@ -752,8 +753,8 @@ object and register it into the web application via the C<register> method.
 
 =back
 
-If we instruct our web application to load the C<JSON> module, it will have a
-new method C<json> which will be a link to the C<JSON> object initialized in the
+If we instruct our web application to load the C<JSON::MaybeXS> module, it will have a
+new method C<json> which will be a link to the C<JSON::MaybeXS> object initialized in the
 module.
 
 See more examples and POD at L<Kelp::Module>.

--- a/lib/Kelp/Manual.pod
+++ b/lib/Kelp/Manual.pod
@@ -90,8 +90,8 @@ module of your choice to return rich text, html and JSON responses.
 
 =item
 
-B<JSON encoder/decoder>. Kelp comes with JSON::MaybeXS, which will
-automatically choose the best (fastest, most secure) backend available.
+B<JSON encoder/decoder>. Kelp comes with JSON, which will automatically choose
+the best (fastest, most secure) backend available (using L<JSON::MaybeXS>).
 
 =item
 

--- a/lib/Kelp/Module/JSON.pm
+++ b/lib/Kelp/Module/JSON.pm
@@ -2,13 +2,13 @@ package Kelp::Module::JSON;
 
 use Kelp::Base 'Kelp::Module';
 
-BEGIN { $ENV{PERL_JSON_BACKEND} //= 'Cpanel::JSON::XS,JSON::XS,JSON::PP' }
-use JSON;
+use JSON::MaybeXS;
 
 sub build {
     my ( $self, %args ) = @_;
-    my $json = JSON->new;
-    $json->property( $_ => $args{$_} ) for keys %args;
+    my $json = JSON::MaybeXS->new(
+        map { $_ => $args{$_} } keys %args
+    );
     $self->register( json => $json );
 }
 
@@ -35,7 +35,5 @@ Kelp::Module::JSON - Simple JSON module for a Kelp application
 This module registers only one method into the application: C<json>.
 
 The module will try to use backends in this order: I<Cpanel::JSON::XS, JSON::XS, JSON::PP>.
-It can be changed by explicitly setting the I<PERL_JSON_BACKEND> environmental variable.
-See L<JSON/CHOOSING BACKEND> for more details.
 
 =cut

--- a/t/module_json.t
+++ b/t/module_json.t
@@ -9,7 +9,7 @@ use Test::More;
     my $m = $app->load_module('JSON');
     isa_ok $m, "Kelp::Module::JSON";
     can_ok $app, $_ for qw/json/;
-    is ref $app->json, 'JSON';
+    is ref $app->json, 'Cpanel::JSON::XS';
 }
 
 done_testing;

--- a/t/module_json.t
+++ b/t/module_json.t
@@ -9,7 +9,11 @@ use Test::More;
     my $m = $app->load_module('JSON');
     isa_ok $m, "Kelp::Module::JSON";
     can_ok $app, $_ for qw/json/;
-    is ref $app->json, 'Cpanel::JSON::XS';
+    ok
+        $app->json->isa('Cpanel::JSON::XS')
+        || $app->json->isa('JSON::XS')
+        || $app->json->isa('JSON::PP'),
+        'JSON method ok';
 }
 
 done_testing;


### PR DESCRIPTION
After some thought I think this is the best course of action to just change the json manager to JSON::MaybeXS without any deprecations:
- backends share the common interface, so there's no need for any deprecations when changing them
- JSON.pm introduced some extra methods, but nowhere in the documentation was said that the `$kelp->json` is actually JSON.pm (other than the module example, which does not document JSON module directly). Using some JSON.pm specific methods were more or less messing with the internals.
- JSON configuration options continue to work the same

Closes #74 