### PR TITLE
Feature: HTTP exceptions

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -265,17 +265,11 @@ sub psgi {
         my $res = $self->res;
 
         if (blessed $exception && $exception->isa('Kelp::Exception')) {
-            my $message = $exception->body;
-
             # No logging here, since it is a message for the user with a code
             # rather than a real exceptional case
+            # (Nothing really broke, user code invoked this)
 
-            $res->set_code($exception->code);
-            if (defined $message) {
-                $res->render($message);
-            } elsif ($res->content_type) {
-                $res->content_type('');
-            }
+            $res->render_exception($exception);
         }
         else {
             my $message = $self->long_error ? longmess($exception) : $exception;

--- a/lib/Kelp/Exception.pm
+++ b/lib/Kelp/Exception.pm
@@ -73,7 +73,9 @@ Readonly.
 Required. Body of the request - can be a string for HTML and a hashref /
 arrayref for JSON responses.
 
-A string will be passed to C<< $response->render_error >> to be rendered inside an error template, if available. A reference will be JSON encoded if JSON is available, otherwise will produce an exception.
+A string will be passed to C<< $response->render_error >> to be rendered inside
+an error template, if available. A reference will be JSON encoded if JSON is
+available, otherwise will produce an exception.
 
 Content type for the response will be set accordingly.
 
@@ -86,6 +88,24 @@ Content type for the response will be set accordingly.
     die Kelp::Exception->new(...);
 
 Same as simply constructing and calling die on an object.
+
+=head1 CAVEATS
+
+=over
+
+=item
+
+Code 500 exceptions will not be logged, as it is considered something that a
+web developer know about. They are not thrown anywhere in Kelp internal code,
+so only user code can fall victim to this.
+
+=item
+
+If there is no content type set, and the exception body is not a reference,
+then a C<text/html> content type will be guessed and the body text will be
+passed to an error template, if available.
+
+=back
 
 =cut
 

--- a/lib/Kelp/Exception.pm
+++ b/lib/Kelp/Exception.pm
@@ -1,0 +1,92 @@
+package Kelp::Exception;
+
+use Kelp::Base;
+
+use Carp;
+
+attr -code => sub { croak 'code is required' };
+
+attr 'body';
+
+sub new {
+    my ($class, $code, %params) = @_;
+
+    croak 'Kelp::Exception can only accept 4XX or 5XX codes'
+        unless defined $code && $code =~ /^[45]\d\d$/;
+
+    $params{code} = $code;
+    return $class->SUPER::new(%params);
+}
+
+sub throw {
+    my $class = shift;
+    my $ex = $class->new(@_);
+    die $ex;
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Kelp::Exception - Tiny HTTP exceptions
+
+=head1 SYNOPSIS
+
+    Exception->throw(400, body => 'The request was malformed');
+
+    # code is optional - 500 by default
+    Kelp::Exception->throw;
+
+    # can control what user sees - even in deployment (unlike string exceptions)
+    Kelp::Exception->throw(501, body => {
+        status => \0,
+        error => 'This method is not yet implemented'
+    });
+
+=head1 DESCRIPTION
+
+This module offers a fine-grained control of what the user sees when an
+exception occurs. Generally, this could also be done by setting the
+result code manually, but that requires passing the Kelp instance around and
+does not immediately end the handling code. Exceptions are a way to end route
+handler execution from deep within the call stack.
+
+This implementation is very incomplete and can only handle 4XX and 5XX status
+codes, meaning that you can't do redirects and normal responses like this. It
+also tries to maintain some degree of compatibility with L<HTTP::Exception>
+without its complexity.
+
+=head1 ATTRIBUTES
+
+=head2 code
+
+HTTP status code. Only possible are 5XX and 4XX.
+
+Readonly.
+
+=head2 body
+
+Required. Body of the request - can be a string for HTML and a hashref /
+arrayref for JSON responses.
+
+A string will be passed to C<< $response->render_error >> to be rendered inside an error template, if available. A reference will be JSON encoded if JSON is available, otherwise will produce an exception.
+
+Content type for the response will be set accordingly.
+
+=head1 METHODS
+
+=head2 throw
+
+    # both do exactly the same
+    Kelp::Exception->throw(...);
+    die Kelp::Exception->new(...);
+
+Same as simply constructing and calling die on an object.
+
+=cut
+
+

--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -137,6 +137,30 @@ sub render_error {
     return $self;
 }
 
+sub render_exception {
+    my ( $self, $exception ) = @_;
+
+    my $code = $exception->code;
+    my $body = $exception->body;
+
+    $self->set_code($code);
+    if ( defined $body ) {
+        my $is_html = $self->content_type =~ m{^text/html};
+        my $guess_html = !$self->content_type && !ref($body);
+
+        if ( $is_html || $guess_html ) {
+            $self->render_error($code, $body);
+        }
+        else {
+            $self->render($body);
+        }
+
+    }
+    elsif ( $self->content_type ) {
+        $self->content_type('');
+    }
+}
+
 sub render_404 {
     $_[0]->render_error( 404, "File Not Found" );
 }

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -1,0 +1,48 @@
+use Kelp::Base -strict;
+
+use Kelp;
+use Kelp::Test;
+use HTTP::Request::Common;
+use Kelp::Exception;
+use Test::More;
+
+my $app = Kelp->new( mode => 'test' );
+my $t = Kelp::Test->new( app => $app );
+
+$app->add_route( "/0", sub { die 'died' });
+$t->request( GET "/0" )
+    ->code_is(500)
+    ->content_like(qr/died/)
+    ->content_type_is('text/html');
+
+$app->add_route( "/1", sub { Kelp::Exception->throw(400) });
+$t->request( GET "/1" )
+    ->code_is(400)
+    ->content_is('')
+    ->content_type_is('text/html');
+
+$app->add_route( "/2", sub { Kelp::Exception->throw(403, body => 'body text') });
+$t->request( GET "/2" )
+    ->code_is(403)
+    ->content_is('body text')
+    ->content_type_is('text/html');
+
+$app->add_route( "/3", sub { Kelp::Exception->throw(501, body => {json => 'object'}) });
+$t->request( GET "/3" )
+    ->code_is(501)
+    ->content_is('{"json":"object"}')
+    ->content_type_is('application/json');
+
+$app->add_route( "/4", sub { Kelp::Exception->throw(503, body => [qw(json array)]) });
+$t->request( GET "/4" )
+    ->code_is(503)
+    ->content_is('["json", "array"]')
+    ->content_type_is('application/json');
+
+$app->add_route( "/5", sub { shift->res->json; Kelp::Exception->throw(500) });
+$t->request( GET "/5" )
+    ->code_is(500)
+    ->content_is('')
+    ->content_type_is('application/json');
+
+done_testing;

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -16,33 +16,46 @@ $t->request( GET "/0" )
     ->content_type_is('text/html');
 
 $app->add_route( "/1", sub { Kelp::Exception->throw(400) });
-$t->request( GET "/1" )
-    ->code_is(400)
-    ->content_is('')
-    ->content_type_is('text/html');
-
 $app->add_route( "/2", sub { Kelp::Exception->throw(403, body => 'body text') });
-$t->request( GET "/2" )
-    ->code_is(403)
-    ->content_is('body text')
-    ->content_type_is('text/html');
-
 $app->add_route( "/3", sub { Kelp::Exception->throw(501, body => {json => 'object'}) });
-$t->request( GET "/3" )
-    ->code_is(501)
-    ->content_is('{"json":"object"}')
-    ->content_type_is('application/json');
-
 $app->add_route( "/4", sub { Kelp::Exception->throw(503, body => [qw(json array)]) });
-$t->request( GET "/4" )
-    ->code_is(503)
-    ->content_is('["json", "array"]')
-    ->content_type_is('application/json');
-
 $app->add_route( "/5", sub { shift->res->json; Kelp::Exception->throw(500) });
-$t->request( GET "/5" )
+
+# these errors should be the same regardless of mode
+for (qw(deployment development)) {
+    $app->mode($_);
+
+    $t->request( GET "/1" )
+        ->code_is(400)
+        ->content_is('')
+        ->content_type_is('');
+
+    $t->request( GET "/2" )
+        ->code_is(403)
+        ->content_is('body text')
+        ->content_type_is('text/html');
+
+    $t->request( GET "/3" )
+        ->code_is(501)
+        ->content_is('{"json":"object"}')
+        ->content_type_is('application/json');
+
+    $t->request( GET "/4" )
+        ->code_is(503)
+        ->content_is('["json","array"]')
+        ->content_type_is('application/json');
+
+    $t->request( GET "/5" )
+        ->code_is(500)
+        ->content_is('')
+        ->content_type_is('');
+
+}
+
+$app->add_route( "/6", sub { Kelp::Exception->throw(300) });
+$t->request( GET "/6" )
     ->code_is(500)
-    ->content_is('')
-    ->content_type_is('application/json');
+    ->content_like(qr/5XX/)
+    ->content_type_is('text/html');
 
 done_testing;

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -17,6 +17,7 @@ $t->request( GET "/0" )
 
 $app->add_route( "/1", sub { Kelp::Exception->throw(400) });
 $app->add_route( "/2", sub { Kelp::Exception->throw(403, body => 'body text') });
+$app->add_route( "/2alt", sub { Kelp::Exception->throw(404, body => 'body text') });
 $app->add_route( "/3", sub { Kelp::Exception->throw(501, body => {json => 'object'}) });
 $app->add_route( "/4", sub { Kelp::Exception->throw(503, body => [qw(json array)]) });
 $app->add_route( "/5", sub { shift->res->json; Kelp::Exception->throw(500) });
@@ -32,7 +33,12 @@ for (qw(deployment development)) {
 
     $t->request( GET "/2" )
         ->code_is(403)
-        ->content_is('body text')
+        ->content_is('403 - body text')
+        ->content_type_is('text/html');
+
+    $t->request( GET "/2alt" )
+        ->code_is(404)
+        ->content_like(qr/Four Oh Four/)
         ->content_type_is('text/html');
 
     $t->request( GET "/3" )


### PR DESCRIPTION
HTTP exceptions are a way to end route handling code early from deep within the call stack. 

This is a lightweight implementation that should have close to zero overhead over what's already there. `Kelp::Exception` only handles 4XX/5XX codes and only contains error code / body to return. `HTTP::Exception` module would be a replacement to it, but it is pretty heavyweight (close to 20 dependencies total).

In theory, user can have more error codes if they throw a subclass of `Kelp::Exception` and use their own Response class that handles it. Old exception handling code is unchanged, but wrapped inside an `if` that checks if the thrown object is not a subclass of `Kelp::Exception`.

They should also correctly use all error templates (when response is html or guessed html). Naturally, all the tests pass.