### PR TITLE
Release 1.06

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2022-05-09: Version 1.06
+            [Changes]
+            - Removed broken homepage link
+
 2021-01-21: Version 1.05
             [New Features]
             - Added HTTP exceptions through Kelp::Exception
@@ -259,3 +263,4 @@
 
 2013-04-12: Version 0.1
             First upload to CPAN
+

--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -12,7 +12,7 @@ use Plack::Util;
 use Class::Inspector;
 use Scalar::Util qw(blessed);
 
-our $VERSION = '1.05';
+our $VERSION = '1.06';
 
 # Basic attributes
 attr -host => hostname;
@@ -653,3 +653,4 @@ This module and all the modules in this package are governed by the same license
 as Perl itself.
 
 =cut
+


### PR DESCRIPTION
Hello Stefan, I hope you're doing well.

I'm back to do one more release of Kelp. Been using it for some of my projects along the way and it's been rock stable, so I don't want to change any code.

We have one deprecated thing going on (unsafe params), but I figured out there's no real need to remove it. People who use it are already getting warned about the safety problem constantly, and breaking their code won't help anyone. I'd just keep it there with the current warning.

What I want to do is to remove the homepage of the module, which points to my previous domain brtastic.xyz. My current domain is bbrtj.eu, but there's no easy way to change a homepage of a module on CPAN. While the old address works, I haven't got SSL cert for it which makes it look really bad. It will expire in a couple months anyway.

While my new domain is paid for whole 10 years, I figured out it's better not to have homepage at all. Having it does not change much, but when it breaks it looks amateurish. Metacpan + github are more than enough.

**Important:** If you merge this, please also remove the homepage ([brtastic.xyz/project/kelp](https://brtastic.xyz/project/kelp)) from the github's repository page, which is where Dist::Zilla takes it from. I will then make my last release to CPAN - unless you want to do it yourself, it's your creation after all, so you deserve to have your name on metacpan's page of the module.