### PR TITLE
Use dedicated pattern building method in Kelp::Routes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2024-06-02: Version 1.07
+            [Changes]
+            - Kelp::Routes now uses a dedicated method to build a pattern object
+
 2022-05-09: Version 1.06
             [Changes]
             - Removed broken homepage link

--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ Benjamin Hengst (notbenh)
 
 Nikolay Mishin (@mishin)
 
-Bartosz Jarzyna (@brtastic)
+Bartosz Jarzyna (bbrtj)
+

--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -12,7 +12,7 @@ use Plack::Util;
 use Class::Inspector;
 use Scalar::Util qw(blessed);
 
-our $VERSION = '1.06';
+our $VERSION = '1.07';
 
 # Basic attributes
 attr -host => hostname;

--- a/lib/Kelp/Manual.pod
+++ b/lib/Kelp/Manual.pod
@@ -825,9 +825,10 @@ Benjamin Hengst (notbenh)
 
 Nikolay Mishin (@mishin)
 
-Bartosz Jarzyna (@brtastic)
+Bartosz Jarzyna (bbrtj)
 
 =head1 LICENSE
 
 This module and all the modules in this package are governed by the same license
 as Perl itself.
+

--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -3,13 +3,13 @@ package Kelp::Routes;
 use Carp;
 
 use Kelp::Base;
-use Kelp::Routes::Pattern;
 use Plack::Util;
 use Class::Inspector;
 
-attr base    => '';
-attr routes  => sub { [] };
-attr names   => sub { {} };
+attr base        => '';
+attr pattern_obj => 'Kelp::Routes::Pattern';
+attr routes      => sub { [] };
+attr names       => sub { {} };
 
 # Cache
 attr _CACHE => sub { {} };
@@ -119,7 +119,7 @@ sub _parse_route {
     }
 
     # Create pattern object
-    push @{ $self->routes }, Kelp::Routes::Pattern->new(%$val);
+    push @{ $self->routes }, $self->build_pattern( $val );
 
     # Add route index to names
     if ( my $name = $val->{name} ) {
@@ -133,6 +133,14 @@ sub _parse_route {
         my ( $k, $v ) = splice( @$tree, 0, 2 );
         $self->_parse_route( $val, $k, $v );
     }
+}
+
+# Override to use a custom pattern object
+sub build_pattern {
+    my ( $self, $args ) = @_;
+    my $package = $self->pattern_obj;
+    eval qq{require $package};
+    return $package->new( %$args );
 }
 
 sub url {
@@ -687,3 +695,4 @@ the application instance into a controller class.
 This module was inspired by L<Routes::Tiny>.
 
 =cut
+


### PR DESCRIPTION
This is pretty much a no-brainer, so I'm going to merge and release it straight away. Edit: whoops, need a review after all.

I've been hacking on Kelp lately for my project and found the ways to extend Kelp::Routes skimpy. Kelp::Routes::Pattern is used statically and in the bowels of `_parse_route` method. It's rather hard to subclass it if you need a bit more than overriding the `dispatch` method.

To combat this I crafted this simple fix: use the same routine to build the pattern as main Kelp.pm uses to build requests and responses. It improves internal consistency and should have no drawbacks.