### PR TITLE
Remove safe_param code, make param safe by default

### DIFF
--- a/lib/Kelp/templates/kelp/conf-config.pl.gen
+++ b/lib/Kelp/templates/kelp/conf-config.pl.gen
@@ -1,6 +1,5 @@
 # Common settings
 {
-    safe_param   => 1, # safer param method
     modules      => [qw/Template JSON Logger/],
     modules_init => {
 
@@ -38,3 +37,4 @@
         }
     }
 };
+

--- a/t/safe_param.t
+++ b/t/safe_param.t
@@ -16,14 +16,10 @@ $app->add_route(
     }
 );
 
-for my $is_safe (0 .. 1) {
-    $app->config_hash->{safe_param} = $is_safe;
-
-    $t->request(GET '/safe/tval?test=sth')
-        ->content_is('tval 1 sth');
-    $t->request(GET '/safe/tval?test=sth&test=sth_else')
-        ->content_is('tval 1 ' . ($is_safe ? 'sth_else' : 'sth sth_else'));
-}
+$t->request(GET '/safe/tval?test=sth')
+    ->content_is('tval 1 sth');
+$t->request(GET '/safe/tval?test=sth&test=sth_else')
+    ->content_is('tval 1 ' . 'sth_else');
 
 done_testing;
 
@@ -36,3 +32,4 @@ sub check_safe {
     my $params = $kelp->param;
     return join ' ', $val, $params, @params;
 }
+


### PR DESCRIPTION
I think it's time to remove the deprecated behavior from `param` and the configuration of `safe_param`:
- It's been deprecated for over 3 years (january 2021)
- test suite is issuing warnings about it constantly, since safe_param is not the default. There are a lot of config files in the test suite so it's quite hard to make sure every test has `safe_param` config
- full app generated with `Kelp` utility has `safe_param` configured, but less app is vulnerable by default

The test suite passes with that new default unchanged.

I guess the next version number should be bumped to 1.10 (at least) since it is a behavior change. I'll take care of that later.