### PR TITLE
Refactor: unify how req and res are used in Kelp::psgi

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -212,8 +212,8 @@ sub psgi {
         for my $route (@$match) {
 
             # Dispatch
-            $self->req->named( $route->named );
-            $self->req->route_name( $route->name );
+            $req->named( $route->named );
+            $req->route_name( $route->name );
             my $data = $self->routes->dispatch( $self, $route );
 
             # Log info about the route
@@ -245,7 +245,7 @@ sub psgi {
         }
 
         # If nothing got rendered
-        if ( !$self->res->rendered ) {
+        if ( !$res->rendered ) {
             # render 404 if only briges matched
             if ( $match->[-1]->bridge ) {
                 $res->render_404;
@@ -262,7 +262,6 @@ sub psgi {
     }
     catch {
         my $exception = $_;
-        my $res = $self->res;
 
         if (blessed $exception && $exception->isa('Kelp::Exception')) {
             # No logging here, since it is a message for the user with a code


### PR DESCRIPTION
This is a minor refactor which changes how request and response objects are used when handling a request. It removes a mixed use of `$req` vs `$self->req` and `$res` vs `$self->res`, and consistently uses the lexical variables it created at the top of the function.

There's a slight possibility an user application would replace req or res while handling it, but then the old code would be wrong as well.