### PR TITLE
Implement before_dispatch method in Kelp

### DIFF
--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -179,12 +179,11 @@ sub dispatch {
     $route || die "No route pattern instance supplied";
 
     # Shortcuts
-    my $req = $app->req;
     my $to  = $route->to;
 
     # Destination must be either a scalar, or a code reference
-    if ( !$to || ref $to && ref $to ne 'CODE' ) {
-        die 'Invalid destination for ' . $req->path;
+    if ( !$to || ( ref $to && ref $to ne 'CODE' ) ) {
+        die 'Invalid destination for ' . $app->req->path;
     }
 
     # If the destination is not a code reference, then we assume it's
@@ -193,7 +192,7 @@ sub dispatch {
 
         # Check if the destination function exists
         unless ( exists &$to ) {
-            die sprintf( 'Route not found %s for %s', $to, $req->path );
+            die sprintf( 'Route not found %s for %s', $to, $app->req->path );
         }
 
         # Move to reference

--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -199,6 +199,7 @@ sub dispatch {
         $to = \&{$to};
     }
 
+    $app->before_dispatch( $route->to );
     return $to->( $app, @{ $route->param } );
 }
 

--- a/lib/Kelp/Routes/Controller.pm
+++ b/lib/Kelp/Routes/Controller.pm
@@ -16,6 +16,8 @@ sub dispatch {
         or croak "Invalid controller '$to'";
 
     my $controller = $app->_clone($controller_class);
+
+    $controller->before_dispatch($action);
     return $controller->$action(@{ $match->param });
 }
 
@@ -78,3 +80,4 @@ functionality.
 
 
 =cut
+

--- a/t/lib/MyApp.pm
+++ b/t/lib/MyApp.pm
@@ -3,6 +3,11 @@ use Kelp::Base 'Kelp';
 use MyApp::Response;
 use UtilPackage;
 
+sub before_dispatch {
+    my $self = shift;
+    $self->res->header( 'X-Before-Dispatch', 'MyApp' );
+}
+
 sub before_finalize {
     my $self = shift;
     $self->res->header( 'X-Test', 'MyApp' );
@@ -33,3 +38,4 @@ sub blessed {
 sub check_util_fun { path; }
 
 1;
+

--- a/t/subclassed.t
+++ b/t/subclassed.t
@@ -13,6 +13,7 @@ $t->request( GET '/test' )
     ->code_isnt(500)
     ->content_is("OK")
     ->content_isnt("FAIL")
+    ->header_is("X-Before-Dispatch", "MyApp")
     ->header_is("X-Test", "MyApp")
     ->header_isnt("X-Framework", "Perl Kelp");
 
@@ -34,3 +35,4 @@ dies_ok {
 } 'dies when missing class';
 
 done_testing;
+


### PR DESCRIPTION
This is a fix to `info` level log pollution caused by uncontrollable access logs. There was no way to disable them other than disabling the `info` level or the logger altogether.

I figured it's better to move access logging into a method instead of creating another configuration field for it. This way users can change the format, disable it, or use the method for something else.

Since the `Routes::Controller` router is reblessing the app into the proper class as a last step, I had to move the method call to the router's code (to not end up with half-working solution). Custom routers will therefore not call this method, but all they will lose are the access logs.